### PR TITLE
feat: Adds support for custom OpenAI-compatible APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Set the following ENV variables for authentication:
 
 If you prefer to use OpenAI to extract context you can set following variables:
  - `OPENAI_KEY` - OpenAI API key.
+ - `OPENAI_BASE_URL` - OpenAI-compatible API base URL (optional, defaults to https://api.openai.com/v1).
 
 If you prefer to use Google Gemini (Vertex AI API) to extract context you can set following variables:
 - `GOOGLE_VERTEX_PROJECT` - project identifier from Google Cloud Console;
@@ -81,6 +82,7 @@ crowdin-context-harvester harvest\
     --project=<project-id>\
     --ai="openai"\
     --openAiKey="<your-openai-token>"\
+    --openAiBaseUrl="http://localhost:8000/v1"\
     --model="gpt-4o"\
     --localFiles="**/*.*"\
     --localIgnore="node_modules/**"\
@@ -91,7 +93,7 @@ crowdin-context-harvester harvest\
     --maxOutputTokens="16384"
 ```
 
-__Note:__ The `url` argument is required for Crowdin Enterprise only. Passing all credentials as environment variables is recommended.
+__Note:__ The `url` argument is required for Crowdin Enterprise only. The `openAiBaseUrl` argument allows you to use custom OpenAI-compatible endpoints (e.g., local LLMs, third-party APIs). Passing all credentials as environment variables is recommended.
 
 When this command is executed, the CLI will pull strings from all Crowdin files that match the `--crowdinFiles` glob pattern, then go through all files that match `--localFiles`, check if strings from Crowdin files are present in every file on your computer (because of the `--screen="keys"`), and if they are, both matching strings and the code files will be sent to LLM with a prompt to extract contextual information, information about how these strings are used in the code, how they appear to the end user in the UI, etc.
 

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ const tokenEnvName = 'CROWDIN_PERSONAL_TOKEN';
 const baseUrlEnvName = 'CROWDIN_BASE_URL';
 const projectEnvName = 'CROWDIN_PROJECT_ID';
 const openApiEnvName = 'OPENAI_KEY';
+const openAiBaseUrlEnvName = 'OPENAI_BASE_URL';
 const googleVertexProjectEnvName = 'GOOGLE_VERTEX_PROJECT';
 const googleVertexLocationEnvName = 'GOOGLE_VERTEX_LOCATION';
 const googleVertexClientEmailEnvName = 'GOOGLE_VERTEX_CLIENT_EMAIL';
@@ -54,6 +55,7 @@ program
     .addOption(new Option('-t, --token <token>', 'Crowdin Personal API token (with Project, AI scopes)').env(tokenEnvName))
     .addOption(new Option('-u, --url <base-url>', 'Crowdin API url (for enterprise https://<org-name>.api.crowdin.com)').env(baseUrlEnvName))
     .addOption(new Option('-k, --openAiKey <openai-api-key>', 'OpenAI API key. Setting this option as an environment variable is recommended.').env(openApiEnvName))
+    .addOption(new Option('-ob, --openAiBaseUrl <openai-base-url>', 'OpenAI-compatible API base URL (e.g., http://localhost:8000/v1). Setting this option as an environment variable is recommended.').env(openAiBaseUrlEnvName))
     .addOption(new Option('-gvp, --googleVertexProject <google-vertext-project-id>', 'Google Cloud Project ID. Setting this option as an environment variable is recommended.').env(googleVertexProjectEnvName))
     .addOption(new Option('-gvl, --googleVertexLocation <google-vertext-location>', 'Google Cloud Project location. Setting this option as an environment variable is recommended.').env(googleVertexLocationEnvName))
     .addOption(new Option('-gvce, --googleVertexClientEmail <google-vertext-client-email>', 'Google Cloud service account client email. Setting this option as an environment variable is recommended.').env(googleVertexClientEmailEnvName))
@@ -75,6 +77,7 @@ program
     .addOption(new Option('-a, --ai <provider>', 'AI provider ("crowdin", "openai", "google-vertex", "azure", "anthropic" or "mistral").').default('openai').makeOptionMandatory())
     .addOption(new Option('-ci, --crowdinAiId <id>', 'Crowdin AI provider ID (e.g. 12). This option is mandatory if "crowdin" is chosen as the AI provider.'))
     .addOption(new Option('-k, --openAiKey <key>', 'OpenAI API key. This option is mandatory if "openai" is chosen as the AI provider.').env(openApiEnvName))
+    .addOption(new Option('-ob, --openAiBaseUrl <base-url>', 'OpenAI-compatible API base URL (e.g., http://localhost:8000/v1). This option is optional when "openai" is chosen as the AI provider.').env(openAiBaseUrlEnvName))
     .addOption(new Option('-gvp, --googleVertexProject <google-vertext-project-id>', 'Google Cloud Project ID. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexProjectEnvName))
     .addOption(new Option('-gvl, --googleVertexLocation <google-vertext-location>', 'Google Cloud Project location. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexLocationEnvName))
     .addOption(new Option('-gvce, --googleVertexClientEmail <google-vertext-client-email>', 'Google Cloud service account client email. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexClientEmailEnvName))
@@ -108,6 +111,7 @@ Examples:
     $ crowdin-context-harvester harvest --project=462 --crowdinFiles="strings.xml" --localFiles="src/*"
     $ crowdin-context-harvester harvest --project=462 --croql='not (context contains "✨ AI Context")'
     $ crowdin-context-harvester harvest --project=462 --croql="added between '2023-12-06 13:44:14' and '2023-12-07 13:44:14'" --output=terminal
+    $ crowdin-context-harvester harvest --project=462 --ai="openai" --openAiKey="sk-xxx" --openAiBaseUrl="http://localhost:8000/v1"
     `)
     .action(harvest);
 
@@ -120,6 +124,7 @@ program
   .addOption(new Option('-a, --ai <provider>', 'AI provider ("crowdin", "openai", "google-vertex", "azure", "anthropic" or "mistral").').default('openai').makeOptionMandatory())
   .addOption(new Option('-ci, --crowdinAiId <id>', 'Crowdin AI provider ID (e.g. 12). This option is mandatory if "crowdin" is chosen as the AI provider.'))
   .addOption(new Option('-k, --openAiKey <key>', 'OpenAI API key. This option is mandatory if "openai" is chosen as the AI provider.').env(openApiEnvName))
+  .addOption(new Option('-ob, --openAiBaseUrl <base-url>', 'OpenAI-compatible API base URL (e.g., http://localhost:8000/v1). This option is optional when "openai" is chosen as the AI provider.').env(openAiBaseUrlEnvName))
   .addOption(new Option('-gvp, --googleVertexProject <google-vertext-project-id>', 'Google Cloud Project ID. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexProjectEnvName))
   .addOption(new Option('-gvl, --googleVertexLocation <google-vertext-location>', 'Google Cloud Project location. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexLocationEnvName))
   .addOption(new Option('-gvce, --googleVertexClientEmail <google-vertext-client-email>', 'Google Cloud service account client email. This option is mandatory if "google-vertex" is chosen as the AI provider.').env(googleVertexClientEmailEnvName))

--- a/src/configure.js
+++ b/src/configure.js
@@ -52,7 +52,7 @@ async function configureCli(_name, commandOptions, _command) {
         message: 'AI provider:',
         choices: [
           { name: 'Crowdin AI Provider', value: 'crowdin' },
-          { name: 'OpenAI', value: 'openai' },
+          { name: 'OpenAI (OpenAI API or OpenAI-compatible API)', value: 'openai' },
           { name: 'Google Gemini (Vertex AI API)', value: 'google-vertex' },
           { name: 'MS Azure OpenAI', value: 'azure' },
           { name: 'Anthropic', value: 'anthropic' },
@@ -85,6 +85,11 @@ async function configureCli(_name, commandOptions, _command) {
         name: 'openai_key',
         message: 'OpenAI API key:',
         when: (answers) => answers.ai === 'openai' && !options.openAiKey,
+    }, {
+        type: 'input',
+        name: 'openai_base_url',
+        message: 'OpenAI-compatible API base URL (optional, defaults to https://api.openai.com/v1):',
+        when: (answers) => answers.ai === 'openai' && !options.openAiBaseUrl,
     }, {
         type: 'input',
         name: 'google_vertex_project',
@@ -157,7 +162,9 @@ async function configureCli(_name, commandOptions, _command) {
 
             if (answers.ai === 'openai') {
                 try {
-                    const openAiModels = (await axios.get('https://api.openai.com/v1/models', {
+                    // Use custom base URL if provided, otherwise default to OpenAI
+                    const baseUrl = process.env.OPENAI_BASE_URL || answers.openai_base_url || 'https://api.openai.com/v1';
+                    const openAiModels = (await axios.get(`${baseUrl}/models`, {
                         headers: {
                             "Authorization": `Bearer ${process.env.OPENAI_KEY || answers.openai_key}`
                         }
@@ -305,6 +312,7 @@ async function configureCli(_name, commandOptions, _command) {
         chalk.yellow('--project=') + chalk.white(`${answers.project} `) +
         chalk.yellow('--ai=') + chalk.white(`"${answers.ai}" `) +
         (answers.openai_key && !options.openAiKey ? chalk.yellow('--openAiKey=') + chalk.white(`"${answers.openai_key}" `) : '') +
+        (answers.openai_base_url && !options.openAiBaseUrl ? chalk.yellow('--openAiBaseUrl=') + chalk.white(`"${answers.openai_base_url}" `) : '') +
         (answers.google_vertex_project && !options.googleVertexProject ? chalk.yellow('--googleVertexProject=') + chalk.white(`"${answers.google_vertex_project}" `) : '') +
         (answers.google_vertex_location && !options.googleVertexLocation ? chalk.yellow('--googleVertexLocation=') + chalk.white(`"${answers.google_vertex_location}" `) : '') +
         (answers.google_vertex_client_email && !options.googleVertexClientEmail ? chalk.yellow('--googleVertexClientEmail=') + chalk.white(`"${answers.google_vertex_client_email}" `) : '') +

--- a/src/utils.js
+++ b/src/utils.js
@@ -434,9 +434,16 @@ function stringifyStrings({ strings}) {
  */
 function getAiClient(options) {
     if (options.ai === 'openai') {
-        return createOpenAI({
+        const config = {
             apiKey: options.openAiKey,
-        });
+        };
+        
+        // Add base URL if provided
+        if (options.openAiBaseUrl) {
+            config.baseURL = options.openAiBaseUrl;
+        }
+        
+        return createOpenAI(config);
     }
 
     if (options.ai === 'anthropic') {


### PR DESCRIPTION
Enables the use of custom OpenAI-compatible API endpoints by introducing the `openAiBaseUrl` option.

This allows users to leverage local LLMs, third-party APIs, or specific OpenAI deployments by specifying a base URL other than the default OpenAI API endpoint.

Updates configuration to prompt for the base URL during setup, and modifies the OpenAI client initialization to use the custom base URL when provided.
