### PR TITLE
fix: propagate --croql filter on string-based projects

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -102,14 +102,12 @@ async function getCrowdinFiles({ apiClient, project, filesPattern }) {
 async function fetchCrowdinStrings({ apiClient, project, isStringsProject, container, croql, since }) {
   const filter = {};
 
-  if (isStringsProject) {
+  if (croql) {
+    filter.croql = croql;
+  } else if (isStringsProject) {
     filter.branchId = container.id;
   } else {
-    if (croql) {
-      filter.croql = croql;
-    } else {
-      filter.fileId = container.id;
-    }
+    filter.fileId = container.id;
   }
 
   let crowdinStrings = (await apiClient.sourceStringsApi.withFetchAll().listProjectStrings(project, filter)).data.map(
@@ -326,24 +324,23 @@ async function getCrowdinStrings({ options, apiClient, spinner }) {
   let containers = []; // we call it containers because it can be either files in a regular Crowdin project or branches in a Strings project
 
   try {
-    if (isStringsProject) {
+    if (options.croql) {
+      // when croql is set, we use a single dummy container so the filter is applied project-wide,
+      // regardless of project type (files-based or string-based)
+      containers = [
+        {
+          id: 0,
+          path: 'croql',
+        },
+      ];
+    } else if (isStringsProject) {
       containers = (await apiClient.sourceFilesApi.withFetchAll().listProjectBranches(options.project)).data.map(branch => branch.data);
     } else {
-      if (options.croql) {
-        // because croql filter can't be used with files filter, we create this dummy container as there would no files but we would have strings
-        containers = [
-          {
-            id: 0,
-            path: 'croql',
-          },
-        ];
-      } else {
-        containers = await getCrowdinFiles({
-          apiClient,
-          project: options.project,
-          filesPattern: options.crowdinFiles,
-        });
-      }
+      containers = await getCrowdinFiles({
+        apiClient,
+        project: options.project,
+        filesPattern: options.crowdinFiles,
+      });
     }
   } catch (error) {
     spinner.fail();


### PR DESCRIPTION
## Summary

Fixes the `--croql` filter being silently ignored on string-based projects (`project.type === 1`).

When `harvest` is run on a string-based project with `--croql=...`, the filter is dropped before the API call and every string of every branch gets reprocessed on each run, defeating the documented `not (context contains "✨ AI Context")` pattern.

Closes #117

## Root cause

In `src/utils.js`:

- `fetchCrowdinStrings` set `filter.branchId = container.id` whenever `isStringsProject` was `true`, never propagating `croql` to `listProjectStrings`.
- `getCrowdinStrings` always built a per-branch `containers` list for string-based projects, instead of falling through to the single dummy container path used for files-based projects when CROQL is set.

## Fix

CROQL now wins regardless of project type, mirroring the existing files-based behavior:

- `fetchCrowdinStrings` checks `croql` first, then falls back to `branchId` (string-based) or `fileId` (files-based).
- `getCrowdinStrings` builds the single dummy container array whenever `options.croql` is set, so the filter is applied project-wide in a single API iteration.

## Test plan

- [x] Reproduced the bug on a real string-based Crowdin Enterprise project: pre-fix, `--croql='not (context contains "✨ AI Context")'` reprocessed all strings; post-fix, the same command processes only the strings whose context lacks the marker.
- [x] Verified the same CROQL via `crowdin string list --croql=...` returns the expected counts, confirming the filter is server-side valid.
- [ ] Files-based project regression: behavior unchanged (croql + dummy container path was already the existing logic, just hoisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)