### PR TITLE
fix(harvest): report fetched / with-context / without-context counts

### DIFF
--- a/src/harvest.js
+++ b/src/harvest.js
@@ -117,6 +117,7 @@ async function extractContexts({ strings, options }) {
   const { agent, promptTemplate } = createAgentAndPrompt(options);
 
   const results = [];
+  let withoutContextCount = 0;
   const total = strings.length;
   bar.start(total, 0, { tokens: formatTokens(0) });
 
@@ -126,13 +127,17 @@ async function extractContexts({ strings, options }) {
     worker: async s => {
       const { id, context, tokensUsed } = await processSingleString({ agent, promptTemplate, workingDir, options, string: s });
       totalTokensUsed += tokensUsed || 0;
-      if (context) results.push({ id, context });
+      if (context) {
+        results.push({ id, context });
+      } else {
+        withoutContextCount++;
+      }
       bar.increment(1, { tokens: formatTokens(totalTokensUsed) });
     },
   });
 
   bar.stop();
-  return { contexts: results };
+  return { contexts: results, withoutContextCount };
 }
 
 /**
@@ -273,6 +278,10 @@ async function harvest(_name, commandOptions, _command) {
 
     validateAiProviderFields(options);
 
+    if (options.croql && options.crowdinFiles && options.crowdinFiles !== '**/*.*') {
+      console.log(chalk.yellow(`Note: --crowdinFiles is ignored when --croql is set; CROQL selects strings project-wide.`));
+    }
+
     const apiClient = await getCrowdin(options);
 
     const strings = await getCrowdinStrings({
@@ -296,6 +305,12 @@ async function harvest(_name, commandOptions, _command) {
       console.log('\nError during context appending');
       console.error(error);
     }
+
+    const withContextCount = stringsContext?.contexts?.length ?? 0;
+    const withoutContextCount = stringsContext?.withoutContextCount ?? 0;
+    console.log(
+      `\nFetched ${chalk.green(strings.length)} strings: ${chalk.green(withContextCount)} returned AI context, ${chalk.yellow(withoutContextCount)} returned no context.`,
+    );
 
     if (options.output === 'terminal') {
       dryRunPrint(strings);


### PR DESCRIPTION
## Summary

Makes the end-of-run output disambiguate **strings fetched from Crowdin** (matching `--croql`, `--since`, file filters) from **strings for which the AI model returned context**. Today the only signal is `Processed strings N/N | 100% | X strings updated`, which conflates two very different outcomes and leads users to assume the fetch loop missed strings when in fact the AI returned no context for them.

Refs #114.

## Root cause of the confusion

In `src/harvest.js`:

- `extractContexts` only counts strings where the agent returned a non-empty context (`if (context) results.push(...)`). Strings where the AI returned `null`/empty are silently dropped from the upload set and never reported.
- At the end of a run, the user only sees `${updatedCount} strings updated in Crowdin`. If they ran with `--croql='not (context contains "✨ AI Context")'`, the strings the AI skipped will be re-fetched on the next run because their context still lacks the marker — giving the appearance of a partial / non-exhaustive extraction.

The CroQL fetch is exhaustive (`withFetchAll()` paginates everything). The "missing" strings are an AI-output property, not a fetch-loop property.

## Fix

- `extractContexts` now also counts strings where the AI returned no context (`withoutContextCount`) and exposes it on its return value.
- `harvest` prints a single summary line after extraction:

  ```
  Fetched 12 strings: 5 returned AI context, 7 returned no context.
  ```

- Adds a startup note when `--croql` is combined with a non-default `--crowdinFiles`, since the CLI help already states they cannot be used together but the code silently dropped `--crowdinFiles` on the CroQL path. Surfacing this avoids users wondering why their file pattern had no effect.

## Why this is a separate PR from #118

#118 fixes a strictly different bug: `--croql` being silently dropped on string-based projects (`project.type === 1`), so every string of every branch was reprocessed. That fix is in `src/utils.js` and is orthogonal to the diagnostic output here. #118 does not address #114 because #114 is files-based-friendly and the issue is the AI's output, not the fetch path.

## Test plan

- [x] `prettier --check src/harvest.js` passes.
- [x] `node --check src/harvest.js` passes.
- [x] Manually reasoned through `output=crowdin`, `output=csv`, `output=terminal`, and `--append` paths — the summary line fires for all of them after extraction. The startup note only fires when both `--croql` and a non-default `--crowdinFiles` are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)