### PR TITLE
ci: switch npm publish workflow to staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
         run: npm ci
 
       - name: Publish 'latest'
-        run: npm publish
+        run: npm stage publish


### PR DESCRIPTION
Switched the npm release workflow to staged publishing (npm stage publish). This adds an approval gate before a version becomes installable, reducing supply-chain risk while keeping our CI release flow unchanged otherwise.